### PR TITLE
Mccalluc/configure viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Vitessce adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add Cypress.io tests.
 - Thank-you to NIH on the front page.
 - Add Google Analytics to all pages.
+### Changed
+- Spatial viewport is part of the initial FAKE_API_RESPONSE, instead of being hardcoded.
 
 ## [0.0.13] - 2019-03-26
 ### Changed

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,12 @@ const FAKE_API_RESPONSE = {
   'linnarsson-2018': {
     name: 'Linnarsson - osmFISH',
     description: 'Spatial organization of the somatosensory cortex revealed by cyclic smFISH',
+    views: {
+      spatial: {
+        zoom: -6.5,
+        offset: [200, 200],
+      },
+    },
     layers: [
       'cells',
       'clusters',
@@ -93,13 +99,14 @@ function renderWelcome(id) {
 }
 
 function renderDataset(id, datasetId) {
-  const { layers, name, description } = FAKE_API_RESPONSE[datasetId];
+  const {
+    layers, views, name, description,
+  } = FAKE_API_RESPONSE[datasetId];
   const [sideBig, sideSmall] = [3, 4];
   const [middleBig, middleSmall] = [12 - 2 * sideBig, 12 - 2 * sideSmall];
   const col = 'd-flex flex-column px-2';
   const side = `${col} col-md-${sideBig} col-sm-${sideSmall}`;
   const middle = `${col} col-md-${middleBig} col-sm-${middleSmall}`;
-  // Card around toolpicker seemed like a waste of space
   document.getElementById(id).innerHTML = `
     <div class="container-fluid d-flex h-75 pt-2 pl-2 pr-2">
       <div id="layermanager"><!-- No UI exposure --></div>
@@ -128,7 +135,7 @@ function renderDataset(id, datasetId) {
   renderComponent(<StatusSubscriber />, 'status');
   renderComponent(<TsneSubscriber />, 'tsne');
   renderComponent(<HeatmapSubscriber />, 'heatmap');
-  renderComponent(<SpatialSubscriber />, 'spatial');
+  renderComponent(<SpatialSubscriber view={views.spatial} />, 'spatial');
   renderComponent(<FactorsSubscriber />, 'factors');
   renderComponent(<GenesSubscriber />, 'genes');
 }

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -40,6 +40,7 @@ export default class Spatial extends AbstractSelectableComponent {
       // neighborhoods: true,
     };
     this.setLayerIsVisible = this.setLayerIsVisible.bind(this);
+    this.getInitialViewState = this.getInitialViewState.bind(this);
   }
 
   static defaultProps = {
@@ -71,10 +72,7 @@ export default class Spatial extends AbstractSelectableComponent {
   // These are called from superclass, so they need to belong to instance, I think.
   // eslint-disable-next-line class-methods-use-this
   getInitialViewState() {
-    return {
-      zoom: -6.5,
-      offset: [200, 200], // Required: https://github.com/uber/deck.gl/issues/2580
-    };
+    return this.props.view;
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/components/spatial/SpatialSubscriber.js
+++ b/src/components/spatial/SpatialSubscriber.js
@@ -96,6 +96,7 @@ export default class SpatialSubscriber extends React.Component {
         <div className={BLACK_CARD}>
           <Spatial
             {... this.state}
+            view={this.props.view}
             updateStatus={
               message => PubSub.publish(STATUS_INFO, message)
             }


### PR DESCRIPTION
Fix #113 

@ngehlenborg : Up until this point, all the configuration of the components has been mediated by PubSub... That works, but for events which are only sent once, on initialization, it means there's a lot of wiring code we need to add, but we don't get that much from it.

In this case, though, I'm just passing the data through as a react property. One key difference is that the viewport data is small, and doesn't require a callback... but the large datasets must be loaded asynchronously.

This seems clean and idiomatic to me, but wanted to make you aware.