### PR TITLE
Specify active tool in ToolMenu via enum rather than boolean

### DIFF
--- a/src/components/AbstractSelectableComponent.js
+++ b/src/components/AbstractSelectableComponent.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import DeckGL, { OrthographicView, PolygonLayer, COORDINATE_SYSTEM } from 'deck.gl';
 import ToolMenu from './ToolMenu';
-import { POINTER, SELECT_RECTANGLE, SELECT_POLYGON } from './tools';
+import { POINTER, SELECT_RECTANGLE } from './tools';
 
 /**
  Abstract React component: Provides drag-to-select functionality to subclasses.
@@ -191,7 +191,7 @@ export default class AbstractSelectableComponent extends React.Component {
     const toolProps = {
       setTool: (toolUpdate) => { this.setState({ tool: toolUpdate }); },
       /* eslint-disable react/destructuring-assignment */
-      getTool: () => this.state.tool,
+      isTool: toolCheck => (toolCheck === this.state.tool),
       /* esline-enable */
     };
 

--- a/src/components/AbstractSelectableComponent.js
+++ b/src/components/AbstractSelectableComponent.js
@@ -189,9 +189,9 @@ export default class AbstractSelectableComponent extends React.Component {
     const { tool } = this.state;
 
     const toolProps = {
-      setTool: (toolUpdate) => { this.setState({ tool: toolUpdate }); },
+      setActiveTool: (toolUpdate) => { this.setState({ tool: toolUpdate }); },
       /* eslint-disable react/destructuring-assignment */
-      isTool: toolCheck => (toolCheck === this.state.tool),
+      isActiveTool: toolCheck => (toolCheck === this.state.tool),
       /* esline-enable */
     };
 

--- a/src/components/AbstractSelectableComponent.js
+++ b/src/components/AbstractSelectableComponent.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import DeckGL, { OrthographicView, PolygonLayer, COORDINATE_SYSTEM } from 'deck.gl';
 import ToolMenu from './ToolMenu';
+import { POINTER, SELECT_RECTANGLE, SELECT_POLYGON } from './tools';
 
 /**
  Abstract React component: Provides drag-to-select functionality to subclasses.
@@ -29,7 +30,7 @@ export default class AbstractSelectableComponent extends React.Component {
     };
     this.state = {
       selectionRectangle: undefined,
-      isSelecting: false,
+      tool: POINTER,
     };
   }
 
@@ -45,15 +46,15 @@ export default class AbstractSelectableComponent extends React.Component {
   }
 
   onDragStart(event) {
-    const { isSelecting } = this.state;
-    if (isSelecting) {
+    const { tool } = this.state;
+    if (tool === SELECT_RECTANGLE) {
       this.dragStartCoordinate = event.coordinate;
     }
   }
 
   onDrag(event) {
-    const { isSelecting } = this.state;
-    if (isSelecting && event.coordinate) {
+    const { tool } = this.state;
+    if (tool === SELECT_RECTANGLE && event.coordinate) {
       this.setState({ selectionRectangle: this.getDragRectangle(event) });
       // If you want to update selection during drag, un-comment this:
       //   this.onUpdateSelection(event);
@@ -62,17 +63,17 @@ export default class AbstractSelectableComponent extends React.Component {
   }
 
   onDragEnd(event) {
-    const { isSelecting } = this.state;
-    if (isSelecting) {
+    const { tool } = this.state;
+    if (tool === SELECT_RECTANGLE) {
       this.setState({ selectionRectangle: undefined });
       this.onUpdateSelection(event);
     }
   }
 
   onUpdateSelection(event) {
-    const { isSelecting } = this.state;
+    const { tool } = this.state;
     const { updateCellsSelection } = this.props;
-    if (isSelecting && event.coordinate && updateCellsSelection) {
+    if (tool === SELECT_RECTANGLE && event.coordinate && updateCellsSelection) {
       const {
         xMin, yMin, xMax, yMax,
       } = this.getDragRectangle(event);
@@ -185,14 +186,12 @@ export default class AbstractSelectableComponent extends React.Component {
   }
 
   render() {
-    const { isSelecting } = this.state;
+    const { tool } = this.state;
 
     const toolProps = {
-      setSelectingMode: () => { this.setState({ isSelecting: true }); },
-      setPointingMode: () => { this.setState({ isSelecting: false }); },
+      setTool: (toolUpdate) => { this.setState({ tool: toolUpdate }); },
       /* eslint-disable react/destructuring-assignment */
-      isSelectingMode: () => this.state.isSelecting,
-      isPointingMode: () => !this.state.isSelecting,
+      getTool: () => this.state.tool,
       /* esline-enable */
     };
 
@@ -202,7 +201,7 @@ export default class AbstractSelectableComponent extends React.Component {
       initialViewState: this.getInitialViewState(),
       onViewStateChange: this.onViewStateChange,
     };
-    if (isSelecting) {
+    if (tool === SELECT_RECTANGLE) {
       deckProps = {
         controller: { dragPan: false },
         getCursor: () => 'crosshair',

--- a/src/components/ToolMenu.js
+++ b/src/components/ToolMenu.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { POINTER, SELECT_RECTANGLE, SELECT_POLYGON } from './tools';
+import { POINTER, SELECT_RECTANGLE } from './tools';
 
 export function IconButton(props) {
   const {
@@ -20,26 +20,20 @@ export function IconButton(props) {
 }
 
 export default function ToolMenu(props) {
-  const { setTool, getTool } = props;
+  const { setTool, isTool } = props;
   return (
     <div className="tool">
       <IconButton
         src="https://s3.amazonaws.com/vitessce-data/assets/material/near_me.svg"
         alt="pointer tool"
         onClick={() => setTool(POINTER)}
-        isActive={(getTool() === POINTER)}
+        isActive={isTool(POINTER)}
       />
       <IconButton
         src="https://s3.amazonaws.com/vitessce-data/assets/material/selection.svg"
         alt="select rectangle"
         onClick={() => setTool(SELECT_RECTANGLE)}
-        isActive={(getTool() === SELECT_RECTANGLE)}
-      />
-      <IconButton
-        src="https://s3.amazonaws.com/vitessce-data/assets/material/selection.svg"
-        alt="select polygon"
-        onClick={() => setTool(SELECT_POLYGON)}
-        isActive={(getTool() === SELECT_POLYGON)}
+        isActive={isTool(SELECT_RECTANGLE)}
       />
     </div>
   );

--- a/src/components/ToolMenu.js
+++ b/src/components/ToolMenu.js
@@ -20,20 +20,20 @@ export function IconButton(props) {
 }
 
 export default function ToolMenu(props) {
-  const { setTool, isTool } = props;
+  const { setActiveTool, isActiveTool } = props;
   return (
     <div className="tool">
       <IconButton
         src="https://s3.amazonaws.com/vitessce-data/assets/material/near_me.svg"
         alt="pointer tool"
-        onClick={() => setTool(POINTER)}
-        isActive={isTool(POINTER)}
+        onClick={() => setActiveTool(POINTER)}
+        isActive={isActiveTool(POINTER)}
       />
       <IconButton
         src="https://s3.amazonaws.com/vitessce-data/assets/material/selection.svg"
         alt="select rectangle"
-        onClick={() => setTool(SELECT_RECTANGLE)}
-        isActive={isTool(SELECT_RECTANGLE)}
+        onClick={() => setActiveTool(SELECT_RECTANGLE)}
+        isActive={isActiveTool(SELECT_RECTANGLE)}
       />
     </div>
   );

--- a/src/components/ToolMenu.js
+++ b/src/components/ToolMenu.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { POINTER, SELECT_RECTANGLE, SELECT_POLYGON } from './tools';
+
 export function IconButton(props) {
   const {
     src, alt, onClick, isActive,
@@ -18,22 +20,26 @@ export function IconButton(props) {
 }
 
 export default function ToolMenu(props) {
-  const {
-    setPointingMode, setSelectingMode, isPointingMode, isSelectingMode,
-  } = props;
+  const { setTool, getTool } = props;
   return (
     <div className="tool">
       <IconButton
         src="https://s3.amazonaws.com/vitessce-data/assets/material/near_me.svg"
         alt="pointer tool"
-        onClick={setPointingMode}
-        isActive={isPointingMode()}
+        onClick={() => setTool(POINTER)}
+        isActive={(getTool() === POINTER)}
       />
       <IconButton
         src="https://s3.amazonaws.com/vitessce-data/assets/material/selection.svg"
         alt="select rectangle"
-        onClick={setSelectingMode}
-        isActive={isSelectingMode()}
+        onClick={() => setTool(SELECT_RECTANGLE)}
+        isActive={(getTool() === SELECT_RECTANGLE)}
+      />
+      <IconButton
+        src="https://s3.amazonaws.com/vitessce-data/assets/material/selection.svg"
+        alt="select polygon"
+        onClick={() => setTool(SELECT_POLYGON)}
+        isActive={(getTool() === SELECT_POLYGON)}
       />
     </div>
   );

--- a/src/components/tools.js
+++ b/src/components/tools.js
@@ -1,0 +1,3 @@
+export const POINTER = 'pointer';
+export const SELECT_RECTANGLE = 'select_rectangle';
+export const SELECT_POLYGON = 'select_polygon';

--- a/src/components/tools.js
+++ b/src/components/tools.js
@@ -1,3 +1,2 @@
 export const POINTER = 'pointer';
 export const SELECT_RECTANGLE = 'select_rectangle';
-export const SELECT_POLYGON = 'select_polygon';


### PR DESCRIPTION
Converts the `isSelecting` boolean to enum (using string constants) to be able to specify additional tools such as `SELECT_POLYGON` or `SELECT_LASSO` in the future.

### Questions
- Would it make more sense for the `tools.js` file be located at `src/tools.js` instead of `src/components/tools.js`?