### PR TITLE
Update deck.gl to ^7.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1282,46 +1282,81 @@
         }
       }
     },
-    "@deck.gl/core": {
-      "version": "6.4.10",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-6.4.10.tgz",
-      "integrity": "sha512-L5wlBIbYHeGZYekiI44KltjNapNcGdmteUQ8w0kIQpmJHX4g7EqUlCVAm/1PfXuT6nfD0Fd23HPb9c/Sz9hXUw==",
+    "@deck.gl/aggregation-layers": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-7.1.6.tgz",
+      "integrity": "sha512-4XrggFqib2mNm+1WTZBjh9DSaPZ50nFVE9z8mqdSKm9E7H4HVUdbLZXoIcy1noV/eNJ2OlM4x4ymFGJbLCZV0Q==",
       "requires": {
+        "d3-hexbin": "^0.2.1"
+      }
+    },
+    "@deck.gl/core": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-7.1.6.tgz",
+      "integrity": "sha512-yiSG7JKc2HXptaW5kr69uIyAMEJr6tnQ0nQOQK+gxYO9KV5icrYBtukvj0oxz2psDiOeoy3aGrIL+d/Dmkcsdg==",
+      "requires": {
+        "@luma.gl/core": "^7.1.0",
         "gl-matrix": "^3.0.0",
-        "luma.gl": "^6.4.2",
         "math.gl": "^2.3.0",
-        "mjolnir.js": "^2.0.3",
-        "probe.gl": "^2.0.1",
+        "mjolnir.js": "^2.1.2",
+        "probe.gl": "^3.0.1",
         "seer": "^0.2.4",
         "viewport-mercator-project": "^6.1.0"
       }
     },
-    "@deck.gl/experimental-layers": {
-      "version": "6.4.10",
-      "resolved": "https://registry.npmjs.org/@deck.gl/experimental-layers/-/experimental-layers-6.4.10.tgz",
-      "integrity": "sha512-j5vHBta52tOYZiI5+eohDprNjXr/Gp4HsOncSORECzomyB70TFD2iezdMq0wU9nE86kmNrYYPUY+LKu99KLcrw==",
+    "@deck.gl/geo-layers": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-7.1.6.tgz",
+      "integrity": "sha512-tpmqPuSzAnRDKlHGNLXNzCWjjfUKRWVK3ufqIx99qoNPtFaVAGV47vbTt9/fJhzPFgoG7VCDbArzrL2n7z3CwA==",
       "requires": {
-        "@deck.gl/core": "^6.4.10",
-        "@deck.gl/layers": "^6.4.10"
+        "h3-js": "^3.4.3",
+        "long": "^3.2.0",
+        "s2-geometry": "^1.2.10"
+      }
+    },
+    "@deck.gl/google-maps": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-7.1.6.tgz",
+      "integrity": "sha512-NbwqdSphw4JXgPqnydek0aT2FtkeQkHk842jqkxXqWUPwwZQUOgsttTm0JAkmnLgVbTgwym/eYr49ifu7KMf2A=="
+    },
+    "@deck.gl/json": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-7.1.6.tgz",
+      "integrity": "sha512-AJTR1FjMipl7RqUlStaxdr7rwYB8GfbHwPv6nwwLloU2ARhOPgqRcePWTYXIg9Fn7LU+RYGUoYc1wnkfKxbfRA==",
+      "requires": {
+        "d3-dsv": "^1.0.8"
       }
     },
     "@deck.gl/layers": {
-      "version": "6.4.10",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-6.4.10.tgz",
-      "integrity": "sha512-efFNNTl1CGWXj5eh3O4rHqNIxqJy6ciHolQLNzzvy4fPuNwLtbg7q662+w8++PtJCOPk2EiX7omQZFXF7STmnQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-7.1.6.tgz",
+      "integrity": "sha512-b001lbFDFXWIv7n3YGHHeBaO+3rljt3IxDpQp6g9G7dgkwCQkdNR2XytCnQOjWTofuxelNnBjdnUo3Da0Pv4zg==",
       "requires": {
-        "@deck.gl/core": "^6.4.10",
+        "@loaders.gl/core": "^1.0.3",
+        "@loaders.gl/images": "^1.0.3",
         "@mapbox/tiny-sdf": "^1.1.0",
-        "d3-hexbin": "^0.2.1",
         "earcut": "^2.0.6"
       }
     },
-    "@deck.gl/react": {
-      "version": "6.4.10",
-      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-6.4.10.tgz",
-      "integrity": "sha512-iPyUna/qnG/QIoTT28gclHIMSOElBHCjvpK+yilUuuJwU68RnmuWcol/9GR645XvEAaeqyk48DLdPIuLnne9VQ==",
+    "@deck.gl/mapbox": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-7.1.6.tgz",
+      "integrity": "sha512-gESHNuD3NgzJr+HOE++vBMajTAFF3UHvnGigHR85WHFcuKVvjPMvUGlCnhwiq5VFi2+loYAe+OqH8q1s0IlKsg=="
+    },
+    "@deck.gl/mesh-layers": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-7.1.6.tgz",
+      "integrity": "sha512-2dnKfcvk5XPGAtFaSwgxCXlkF48T+O0RCLMkABiugM68Dn4llBAs51IX7f8TqiXk7r4bzwEbreSTi2B4m2gUQw==",
       "requires": {
-        "@deck.gl/core": "^6.4.10",
+        "@loaders.gl/core": "^1.0.3",
+        "@loaders.gl/images": "^1.0.3"
+      }
+    },
+    "@deck.gl/react": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-7.1.6.tgz",
+      "integrity": "sha512-FjAmhy5QwwFt73T9K7+12aD/DZhEBCfkQMc+QefIm8H+ti9YV+S1RrZi1cWZ5o8e+wRlfOQa49yoGx+fKost8A==",
+      "requires": {
         "prop-types": "^15.6.0"
       }
     },
@@ -1462,10 +1497,83 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
+    "@loaders.gl/core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-1.1.4.tgz",
+      "integrity": "sha512-yzdzHmBEAySj2MoWWvUFT4cV35w2LcPXvjfURy7+ATNHKqMOgad7kDZe15SJ7cvG9VsF7adzr5QqyDfNBDW3tg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1"
+      }
+    },
+    "@loaders.gl/images": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-1.1.4.tgz",
+      "integrity": "sha512-hWoYk8TwMOZNbyh7gqNobVgHEO5uqp91G4eb7Y0vRDnjAQzOIfyLv7A+bunJgEf8InirZ/CWFXIrXxXur5z+AA=="
+    },
+    "@luma.gl/constants": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-7.1.1.tgz",
+      "integrity": "sha512-F+lkZzMJNPvGeTCkOezyHafAb48ottMx10PYx3j1rsKFBM2v1LgBHnV1I37xjkrx8PMhdb/2zMg80nRrniudGw=="
+    },
+    "@luma.gl/core": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-7.1.1.tgz",
+      "integrity": "sha512-C39SmKXiDLyACnYXe5d09Gwh5f011xkNQ8RsE6ffWVGCTWIIb9rK9z1g0L6JuViV/xmWco/sO1SdMQ8uLjC8Zw==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "7.1.1",
+        "@luma.gl/shadertools": "7.1.1",
+        "@luma.gl/webgl": "7.1.1",
+        "@luma.gl/webgl-state-tracker": "7.1.1",
+        "@luma.gl/webgl2-polyfill": "7.1.1",
+        "math.gl": "^2.3.0",
+        "probe.gl": "^3.0.2",
+        "seer": "^0.2.4"
+      }
+    },
+    "@luma.gl/shadertools": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-7.1.1.tgz",
+      "integrity": "sha512-Mr+6LiMUGfnrD9wYEQBa51Far3G33wxNXbl6kGHq4wgyewlpAHPfTuzqLig2o44G7VvGm/BCCAjvr6yXeluUIw==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "math.gl": "^2.3.0"
+      }
+    },
+    "@luma.gl/webgl": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-7.1.1.tgz",
+      "integrity": "sha512-2FkkSFdsE6TeA5dTez/pz44rQEoe8dAmyF+z2jsIrHWtIS+pW16L6R/iGwmwqGrEWgYbFkhihrHI21teNM633g==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "7.1.1",
+        "@luma.gl/webgl-state-tracker": "7.1.1",
+        "@luma.gl/webgl2-polyfill": "7.1.1",
+        "probe.gl": "^3.0.2"
+      }
+    },
+    "@luma.gl/webgl-state-tracker": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl-state-tracker/-/webgl-state-tracker-7.1.1.tgz",
+      "integrity": "sha512-eF63OgMwkt9+XKH9LZ/SIzsZDZiLISfc+jNvRKmT1UyKbxQLJ99V8D9d6tF8GFAl1/0To3d4hdTce2HmjwhXsg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "7.1.1"
+      }
+    },
+    "@luma.gl/webgl2-polyfill": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl2-polyfill/-/webgl2-polyfill-7.1.1.tgz",
+      "integrity": "sha512-UJxDVG4tojuStNi43ERxFiojgkTHi5ScbuL0Msr8id7X7L9UmeCiQ4H6p9m002yy5swCsJlWg/Y8oEtUA5jhqw==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "7.1.1"
+      }
+    },
     "@mapbox/tiny-sdf": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.0.tgz",
-      "integrity": "sha512-dnhyk8X2BkDRWImgHILYAGgo+kuciNYX30CUKj/Qd5eNjh54OWM/mdOS/PWsPeN+3abtN+QDGYM4G220ynVJKA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz",
+      "integrity": "sha512-Ihn1nZcGIswJ5XGbgFAvVumOgWpvIjBX9jiRlIl46uQG9vJOF51ViBYHF95rEZupuyQbEmhLaDPLQlU7fUTsBg=="
     },
     "@mdx-js/loader": {
       "version": "1.0.15",
@@ -6927,10 +7035,6 @@
         }
       }
     },
-    "css-element-queries": {
-      "version": "github:marcj/css-element-queries#5d92e05e136137d11e0203c9d5ca06a99645f601",
-      "from": "github:marcj/css-element-queries"
-    },
     "css-has-pseudo": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
@@ -7515,17 +7619,6 @@
       "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.12.tgz",
       "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
     },
-    "d3-brush": {
-      "version": "github:flekschas/d3-brush#39c15e016ef5253a65da20eee78d192dba3d095d",
-      "from": "github:flekschas/d3-brush",
-      "requires": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
-      }
-    },
     "d3-collection": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
@@ -7864,13 +7957,19 @@
       }
     },
     "deck.gl": {
-      "version": "6.4.10",
-      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-6.4.10.tgz",
-      "integrity": "sha512-0HXPospqYt//H4OsOdp4acqMQyeESnAGs/93xSnbFOBJBGOJ9uH1dVlNxn2Vctqslv5WBvkKYRaoPx6ve3AjGA==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-7.1.6.tgz",
+      "integrity": "sha512-WcmeTmAWMulZKG1DguUASADJGgUzja7NSwkmAOPaaL8q6w2gt4y+U6Uj8qfkpmNqx2UuSRRVhh2C+0PSq72E6w==",
       "requires": {
-        "@deck.gl/core": "^6.4.10",
-        "@deck.gl/layers": "^6.4.10",
-        "@deck.gl/react": "^6.4.10"
+        "@deck.gl/aggregation-layers": "7.1.6",
+        "@deck.gl/core": "7.1.6",
+        "@deck.gl/geo-layers": "7.1.6",
+        "@deck.gl/google-maps": "7.1.6",
+        "@deck.gl/json": "7.1.6",
+        "@deck.gl/layers": "7.1.6",
+        "@deck.gl/mapbox": "7.1.6",
+        "@deck.gl/mesh-layers": "7.1.6",
+        "@deck.gl/react": "7.1.6"
       }
     },
     "decode-uri-component": {
@@ -14114,6 +14213,11 @@
         }
       }
     },
+    "h3-js": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-3.4.3.tgz",
+      "integrity": "sha512-rr+kkErW7DqDlFN1KikjjDEurQxaPb0dJHpcijSzr+/WDjMYK7F9/Qr412HNSG5BkbG8XXK9CbPHVjDI85GYUA=="
+    },
     "hammerjs": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
@@ -14477,11 +14581,9 @@
       "integrity": "sha512-62PTYEzl60JN/xHcUub1gFYnoF+S0yAMDLpqjxvG62x9TJgMI9SVKsRPqufuiFtx1phiDzeY7UCMbdz1GzbYSg==",
       "requires": {
         "box-intersect": "^1.0.1",
-        "css-element-queries": "github:marcj/css-element-queries#5d92e05e136137d11e0203c9d5ca06a99645f601",
         "cwise": "^1.0.10",
         "d3-array": "^1.2.1",
         "d3-axis": "^1.0.4",
-        "d3-brush": "github:flekschas/d3-brush#39c15e016ef5253a65da20eee78d192dba3d095d",
         "d3-color": "^1.0.3",
         "d3-drag": "^1.2.1",
         "d3-dsv": "^1.0.8",
@@ -14502,7 +14604,6 @@
         "prop-types": "^15.6.0",
         "pub-sub-es": "^1.2.0",
         "react": "^16.6.3",
-        "react-autocomplete": "github:tiemevanveen/react-autocomplete#a97a5d8d564fa30968cf0b39b6f9dfd2d5eafb24",
         "react-bootstrap": "0.32.1",
         "react-checkbox-tree": "^1.4.1",
         "react-color": "^2.13.8",
@@ -14524,10 +14625,39 @@
         "whatwg-fetch": "^3.0.0"
       },
       "dependencies": {
+        "css-element-queries": {
+          "version": "github:marcj/css-element-queries#5d92e05e136137d11e0203c9d5ca06a99645f601",
+          "from": "github:marcj/css-element-queries#5d92e05e136137d11e0203c9d5ca06a99645f601"
+        },
+        "d3-brush": {
+          "version": "github:flekschas/d3-brush#39c15e016ef5253a65da20eee78d192dba3d095d",
+          "from": "github:flekschas/d3-brush#39c15e016ef5253a65da20eee78d192dba3d095d",
+          "requires": {
+            "d3-dispatch": "1",
+            "d3-drag": "1",
+            "d3-interpolate": "1",
+            "d3-selection": "1",
+            "d3-transition": "1"
+          }
+        },
         "eventemitter3": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
           "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+        },
+        "react-autocomplete": {
+          "version": "github:tiemevanveen/react-autocomplete#a97a5d8d564fa30968cf0b39b6f9dfd2d5eafb24",
+          "from": "github:tiemevanveen/react-autocomplete#a97a5d8d564fa30968cf0b39b6f9dfd2d5eafb24",
+          "requires": {
+            "dom-scroll-into-view": "1.0.1"
+          },
+          "dependencies": {
+            "dom-scroll-into-view": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.0.1.tgz",
+              "integrity": "sha1-Mqu5Lw2P7KYhUWKu9D5LRJq42Zw="
+            }
+          }
         },
         "url-join": {
           "version": "1.1.0",
@@ -17945,8 +18075,7 @@
     "long": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
-      "dev": true
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
     "longest": {
       "version": "1.0.1",
@@ -17998,18 +18127,6 @@
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
-      }
-    },
-    "luma.gl": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/luma.gl/-/luma.gl-6.4.3.tgz",
-      "integrity": "sha512-1KrupHSZ9H0+OO9AS1d6WGxIX9u0jQh38tSuoXN9sOt3XYH0nJDzNPes37UPaz0m/7Lj2UKc6sJnTC8+u41nfQ==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "math.gl": "^2.3.0",
-        "probe.gl": "^2.0.1",
-        "seer": "^0.2.4",
-        "webgl-debug": "^2.0.0"
       }
     },
     "lz-string": {
@@ -18724,9 +18841,9 @@
       }
     },
     "mjolnir.js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.1.0.tgz",
-      "integrity": "sha512-XVvwByhXGvgWJs/mFsekE1cmg3l/KrRIqaJ5oO5DFEyG//NbQssPIuFOjKrZYQ4rFkRZRq+FN4EcecUPSGR89g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.1.2.tgz",
+      "integrity": "sha512-OjvkNzTCdJd/I7XxgIomNozYS6me6OWY+t8I6SZlINaFmNmgAW3I5x+Hd8sgA+WxAjFvBf576lD7N1MGo89/WA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "hammerjs": "^2.0.8"
@@ -24875,9 +24992,9 @@
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "probe.gl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/probe.gl/-/probe.gl-2.1.0.tgz",
-      "integrity": "sha512-15qr6m/UxJoSatwhDBUnvdPPNfM8j4tHzr7PuXHMVK/sZvc/f4Lo6/4rgHz5iBF5mXRsOtsOGFDsqzAyBQCk+g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/probe.gl/-/probe.gl-3.0.3.tgz",
+      "integrity": "sha512-nkE+rh4m2JRQqorW327X7rVogknVmNvgrtcDG4F3OxckAIHSi4l/PUPy6GVaI6PIUJC7CYx4WYwcdgh4RUJe7A==",
       "requires": {
         "@babel/runtime": "^7.0.0"
       }
@@ -25327,20 +25444,6 @@
           "version": "2.6.4",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
           "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
-        }
-      }
-    },
-    "react-autocomplete": {
-      "version": "github:tiemevanveen/react-autocomplete#a97a5d8d564fa30968cf0b39b6f9dfd2d5eafb24",
-      "from": "github:tiemevanveen/react-autocomplete#fix-176",
-      "requires": {
-        "dom-scroll-into-view": "1.0.1"
-      },
-      "dependencies": {
-        "dom-scroll-into-view": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.0.1.tgz",
-          "integrity": "sha1-Mqu5Lw2P7KYhUWKu9D5LRJq42Zw="
         }
       }
     },
@@ -27236,6 +27339,14 @@
         "tslib": "^1.9.0"
       }
     },
+    "s2-geometry": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/s2-geometry/-/s2-geometry-1.2.10.tgz",
+      "integrity": "sha1-xv8i8+zK/Q7qSRtgtEwUG5iHrKs=",
+      "requires": {
+        "long": "^3.2.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -27625,9 +27736,9 @@
       }
     },
     "seer": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/seer/-/seer-0.2.4.tgz",
-      "integrity": "sha512-d+X19YtDXXK3giW0xYO7DTzLfSqsFoq9gFr0j1g3SqyX63uhbQnZ/UZIJ1Xcr24I3e4JLKqg85q8bbpAOkKNGw=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/seer/-/seer-0.2.5.tgz",
+      "integrity": "sha512-//0Zwt0x97KQhIWrp4oq9AVNvGA2ctCx4dmFddpkORjRr6bW+hyC8eOhWBVIhiU3uHv1XLU1dekfFKOi28RGHA=="
     },
     "select-hose": {
       "version": "2.0.0",
@@ -30876,11 +30987,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.2.tgz",
       "integrity": "sha512-II+n2ms4mPxK+RnIxRPOw3zwF2jRscdJIUE9BfkKHm4FYEg9+biIoTMnaZF5MpemE3T+VhMLrhbyD4ilkPCSbg=="
-    },
-    "webgl-debug": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/webgl-debug/-/webgl-debug-2.0.1.tgz",
-      "integrity": "sha512-G7BOpMmqdc31X1nb3eqwVxw/v1MNV/ulgw7Bs+7+a/sn+fC0d0OiMkerA55C6+3BL2vULyJ3kZLPcEL5GbXzhw=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
     "docz:build": "docz build"
   },
   "dependencies": {
-    "@deck.gl/experimental-layers": "^6.4.7",
+    "@deck.gl/core": "^7.1.4",
+    "@deck.gl/layers": "^7.1.4",
     "ajv": "^6.10.0",
     "d3-scale-chromatic": "^1.3.3",
-    "deck.gl": "^6.4.7",
+    "deck.gl": "^7.1.4",
     "higlass": "^1.5.7",
     "math.gl": "^2.3.1",
     "openseadragon": "^2.4.0",

--- a/src/components/AbstractSelectableComponent.js
+++ b/src/components/AbstractSelectableComponent.js
@@ -196,7 +196,7 @@ export default class AbstractSelectableComponent extends React.Component {
     };
 
     let deckProps = {
-      views: [new OrthographicView({ id: 'ortho' })],
+      views: [new OrthographicView({ id: 'ortho' })], // id is a fix for https://github.com/uber/deck.gl/issues/3259
       layers: this.renderLayers().concat(this.renderSelectionRectangleLayers()),
       initialViewState: this.getInitialViewState(),
       onViewStateChange: this.onViewStateChange,

--- a/src/components/AbstractSelectableComponent.js
+++ b/src/components/AbstractSelectableComponent.js
@@ -196,7 +196,7 @@ export default class AbstractSelectableComponent extends React.Component {
     };
 
     let deckProps = {
-      views: [new OrthographicView()],
+      views: [new OrthographicView({ id: 'ortho' })],
       layers: this.renderLayers().concat(this.renderSelectionRectangleLayers()),
       initialViewState: this.getInitialViewState(),
       onViewStateChange: this.onViewStateChange,


### PR DESCRIPTION
This pull request updates deck.gl to v7 (on which the current version of nebula.gl depends).
The change to AbstractSelectableComponent is based on this comment https://github.com/uber/deck.gl/issues/3259